### PR TITLE
Improve performance of setHiddenNodeIds

### DIFF
--- a/projects/angular-tree-component/src/lib/models/tree.model.ts
+++ b/projects/angular-tree-component/src/lib/models/tree.model.ts
@@ -338,10 +338,10 @@ export class TreeModel implements ITreeModel, OnDestroy {
   }
 
   setHiddenNodeIds(nodeIds) {
-    const ids = nodeIds.reduce((hiddenNodeIds, id) => ({
-      ...hiddenNodeIds,
-      [id]: true
-    }), {});
+    const ids = {} as any;
+    for (const id of nodeIds) {
+      ids[id] = true;
+    }
     this._hiddenNodeIds.set(ids);
   }
 


### PR DESCRIPTION
The old implementation was O(N²), and now its O(N). This actually cost us performance noticeably, on a bigger tree.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/CirclonGroup/angular-tree-component/blob/master/CONTRIBUTING.md#commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Refactoring (no functional changes, no api changes)
[x] Other... Please describe: Performance
```

## What is the current behavior?
The method in question (setHiddenNodeIds) keeps the browser busy for multiple seconds, when working with a large tree with invisible nodes.

Closes #

## What is the new behavior?
Now the performance is much better.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Not sure who has the leading fork of this library atm, but we are using your's - thank you for providing it!

To others who are impacted and can't change the library: We are currently using this fix (which is identical to this PR):

```
// Performance fix for @ali-hm/angular-tree-component setHiddenNodeIds performance issue
TreeModel.prototype.setHiddenNodeIds = function (nodeIds: any[]) {
  // O(N) implementation instead of O(N^2)
  const ids = {} as any;
  for (const id of nodeIds) {
    ids[id] = true;
  }
  (this as any)._hiddenNodeIds.set(ids);
};
```